### PR TITLE
test: reach 100% coverage on Pure project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor
 db.sqlite3
 .phpunit.result.cache
+php-bin

--- a/tests/Unit/Framework/Rendering/TemplateRendererTest.php
+++ b/tests/Unit/Framework/Rendering/TemplateRendererTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Tests\Unit\Framework\Rendering;
 
 use App\Framework\Csrf\StoredTokenReader;
+use App\Framework\Csrf\Token;
 use App\Framework\MessageContainer\FlashMessenger;
 use App\Framework\Rendering\TemplateDirectory;
 use App\Framework\Rendering\TemplateRenderer;
+use App\Framework\Rendering\TwigTemplateRenderer;
 use App\Framework\Rendering\TwigTemplateRendererFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -27,5 +29,57 @@ class TemplateRendererTest extends TestCase
         $renderer = $factory->create();
 
         $this->assertInstanceOf(TemplateRenderer::class, $renderer);
+    }
+
+    public function test_create_get_token_function_returns_token_string(): void
+    {
+        $token = new Token('test-token-value');
+
+        $storedTokenReader = $this->createMock(StoredTokenReader::class);
+        $storedTokenReader->expects($this->once())
+            ->method('read')
+            ->with('csrf_key')
+            ->willReturn($token);
+
+        $templateDir = $this->createMock(TemplateDirectory::class);
+        $templateDir->method('toString')->willReturn(__DIR__);
+
+        $flashMessenger = $this->createMock(FlashMessenger::class);
+
+        $factory = new TwigTemplateRendererFactory($storedTokenReader, $templateDir, $flashMessenger);
+        $renderer = $factory->create();
+
+        $twigEnv = $this->getTwigEnvironment($renderer);
+        $getToken = $twigEnv->getFunction('get_token');
+        $callable = $getToken->getCallable();
+
+        $result = $callable('csrf_key');
+        $this->assertSame('test-token-value', $result);
+    }
+
+    public function test_create_get_flash_bag_function_returns_flash_messenger(): void
+    {
+        $storedTokenReader = $this->createMock(StoredTokenReader::class);
+        $templateDir = $this->createMock(TemplateDirectory::class);
+        $templateDir->method('toString')->willReturn(__DIR__);
+        $flashMessenger = $this->createMock(FlashMessenger::class);
+
+        $factory = new TwigTemplateRendererFactory($storedTokenReader, $templateDir, $flashMessenger);
+        $renderer = $factory->create();
+
+        $twigEnv = $this->getTwigEnvironment($renderer);
+        $getFlashBag = $twigEnv->getFunction('get_flash_bag');
+        $callable = $getFlashBag->getCallable();
+
+        $result = $callable();
+        $this->assertSame($flashMessenger, $result);
+    }
+
+    private function getTwigEnvironment(TwigTemplateRenderer $renderer): \Twig\Environment
+    {
+        $reflection = new \ReflectionClass($renderer);
+        $prop = $reflection->getProperty('twigEnvironment');
+        $prop->setAccessible(true);
+        return $prop->getValue($renderer);
     }
 }

--- a/tests/Unit/Framework/Rendering/TwigTemplateRendererTest.php
+++ b/tests/Unit/Framework/Rendering/TwigTemplateRendererTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Framework\Rendering;
+
+use App\Framework\Rendering\TwigTemplateRenderer;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+
+class TwigTemplateRendererTest extends TestCase
+{
+    public function test_render_delegates_to_twig_environment(): void
+    {
+        $twig = $this->createMock(Environment::class);
+        $twig->expects($this->once())
+            ->method('render')
+            ->with('template.html.twig', ['key' => 'value'])
+            ->willReturn('<html>rendered</html>');
+
+        $renderer = new TwigTemplateRenderer($twig);
+        $result = $renderer->render('template.html.twig', ['key' => 'value']);
+
+        $this->assertSame('<html>rendered</html>', $result);
+    }
+
+    public function test_render_without_data_passes_empty_array(): void
+    {
+        $twig = $this->createMock(Environment::class);
+        $twig->expects($this->once())
+            ->method('render')
+            ->with('Page.html.twig', [])
+            ->willReturn('page content');
+
+        $renderer = new TwigTemplateRenderer($twig);
+        $result = $renderer->render('Page.html.twig');
+
+        $this->assertSame('page content', $result);
+    }
+}

--- a/tests/Unit/Submission/Presentation/SubmissionControllerTest.php
+++ b/tests/Unit/Submission/Presentation/SubmissionControllerTest.php
@@ -9,10 +9,12 @@ use App\Framework\Rendering\TemplateRenderer;
 use App\Framework\RoleBasedAccessControl\AuthenticatedUser;
 use App\Framework\RoleBasedAccessControl\Guest;
 use App\Framework\RoleBasedAccessControl\Permission\SubmitLink;
+use App\Framework\RoleBasedAccessControl\User;
 use App\Submission\Application\SubmitLinkHandler;
 use App\Submission\Presentation\SubmissionController;
 use App\Submission\Presentation\SubmissionForm;
 use App\Submission\Presentation\SubmissionFormFactory;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -133,5 +135,23 @@ class SubmissionControllerTest extends TestCase
         $response = $controller->submit($request);
 
         $this->assertSame('/submit', $response->getTargetUrl());
+    }
+
+    public function test_submit_throws_logic_exception_when_user_has_permission_but_is_not_authenticated_user(): void
+    {
+        // User implements the User interface with permission but is NOT an AuthenticatedUser instance
+        $user = $this->createMock(User::class);
+        $user->method('hasPermission')->willReturn(true);
+
+        $form = $this->createMock(SubmissionForm::class);
+        $form->method('getValidationErrors')->willReturn([]);
+        $this->factory->method('createFromRequest')->willReturn($form);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Only authenticated users can submit links');
+
+        $request = new Request();
+        $controller = new SubmissionController($this->renderer, $this->factory, $this->messenger, $this->handler, $user);
+        $controller->submit($request);
     }
 }


### PR DESCRIPTION
## Summary
- Add `TwigTemplateRendererTest` (new file) covering `render()` with and without data
- Extend `TemplateRendererTest` to exercise `TwigTemplateRendererFactory::create()` — specifically the `get_token` and `get_flash_bag` Twig functions
- Add edge-case to `SubmissionControllerTest`: `LogicException` path when a non-`AuthenticatedUser` somehow has `SubmitLink` permission

## Coverage
Before: Classes 91.18% · Methods 96.84% · Lines 98.10%
After: Classes 100% · Methods 100% · Lines 100% (148 tests, 287 assertions)

## Test plan
- [x] `phpunit --coverage-text` passes locally at 100%
- [x] All 148 tests green

Slack thread: https://slack.com/archives/C0AV6QL6YQ7/p1781160277264949

🤖 Generated with [Claude Code](https://claude.com/claude-code)